### PR TITLE
fix(parse): include BJM in auto_dup outer ref shifting

### DIFF
--- a/clang/parse/auto_dup.c
+++ b/clang/parse/auto_dup.c
@@ -62,7 +62,7 @@ fn void auto_dup_go(u64 loc, u32 lvl, u32 base, u32 *use, u32 n, u32 lab, u8 tgt
   }
 
   // Shift outer refs
-  if ((tg == BJV || tg == BJ0 || tg == BJ1) && vl > base) {
+  if ((tg == BJV || tg == BJ0 || tg == BJ1 || tg == BJM) && vl > base) {
     HEAP[loc] = term_new(0, tg, term_ext(t), vl + n);
     return;
   }


### PR DESCRIPTION
## Summary
- Add BJM to the condition for shifting outer refs in auto_dup transformation
- Fixes de Bruijn level calculation for MOV references when DUP nodes are inserted

## Context
When `auto_dup` inserts DUP nodes for duplicated variables, it shifts de Bruijn levels for outer references. `BJV`, `BJ0`, and `BJ1` were already handled, but `BJM` (MOV's book reference) was missing.

Without this fix, a MOV reference to an outer binding would have the wrong level after auto_dup inserts new binders.

## Test plan
- [ ] Verify MOV references work correctly with duplicated variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)