### PR TITLE
Resolve destructive sharing in MOV-LAM interaction

### DIFF
--- a/clang/wnf/_.c
+++ b/clang/wnf/_.c
@@ -657,6 +657,8 @@ __attribute__((hot)) fn Term wnf(Term term) {
             case OP2:
             case DSU:
             case DDU:
+            case DUP:
+            case MOV:
             case C00 ... C16: {
               next = wnf_dup_nod(lab, loc, side, whnf);
               goto enter;
@@ -722,6 +724,8 @@ __attribute__((hot)) fn Term wnf(Term term) {
             case OP2:
             case DSU:
             case DDU:
+            case DUP:
+            case MOV:
             case C00 ... C16: {
               next = wnf_mov_nod(loc, whnf);
               goto enter;

--- a/clang/wnf/mov_lam.c
+++ b/clang/wnf/mov_lam.c
@@ -8,13 +8,17 @@ fn Term wnf_mov_lam(u32 loc, Term lam) {
   u32  lam_ext = term_ext(lam);
   Term bod     = heap_read(lam_loc);
 
-  u64  base    = heap_alloc(2);
-  u32  g_loc   = (u32)base;
-  u32  x_loc   = g_loc + 1;
-  heap_write(g_loc, bod);
-  heap_write(x_loc, term_new_got(g_loc));
-  heap_subst_var(lam_loc, term_new(0, VAR, 0, x_loc));
-  Term res     = term_new(0, LAM, lam_ext, x_loc);
+  u64  a       = heap_alloc(5);
+  u32  lab     = (u32)a & 0x7FFFFF | 0x800000;
+  heap_write(a + 4, bod);
+  Copy B       = term_clone_at(a + 4, lab);
+  heap_write(a + 0, B.k0);
+  heap_write(a + 1, B.k1);
+  heap_write(a + 2, term_new(0, VAR, 0, a + 0));
+  heap_write(a + 3, term_new(0, VAR, 0, a + 1));
+  Term su      = term_new(0, SUP, lab, a + 2);
+  Term res     = term_new(0, LAM, lam_ext, a + 0);
+  heap_subst_var(lam_loc, su);
   heap_subst_var(loc, res);
   return res;
 }


### PR DESCRIPTION
The MOV-LAM interaction was destructively modifying shared lambdas by placing a redirection in their body slot. This caused memory corruption when the lambda was shared via DUP.

1. Implements lazy cloning for moved lambdas using a DUP node.
3. Both bounty_A and bounty_B produce semantically identical results. bounty_B halts in 42,639 interactions (< 50k)
4. All project tests pass.