### PR TITLE
Fix overflow in count_uses

### DIFF
--- a/src/hvm.c
+++ b/src/hvm.c
@@ -1955,8 +1955,9 @@ fn PBind* parse_bind_lookup(u32 name, int side, int *skipped) {
 // Count the number of uses of a target variable in a term
 // Variables are identified by tag + level (and ext for BJ mode).
 fn u32 count_uses(Term t, u32 lvl, u8 tgt, u32 ext) {
-  Term *ts = (Term*)malloc(sizeof(Term) * 1024); // not recursive, since this is a desugared term
-  int ts_idx = 0;
+  u32 ts_cap = 1024;
+  Term *ts = (Term*)malloc(sizeof(Term) * ts_cap);
+  u32 ts_idx = 0;
   ts[ts_idx++] = t;
 
   u32 uses = 0;
@@ -1970,6 +1971,10 @@ fn u32 count_uses(Term t, u32 lvl, u8 tgt, u32 ext) {
     u32 ari = term_arity(t);
     for (u32 i = 0; i < ari; i++) {
       u64 loc = vl + i;
+      if (ts_idx == ts_cap) {
+        ts_cap *= 2;
+        ts = (Term*)realloc(ts, sizeof(Term) * ts_cap);
+      }
       ts[ts_idx++] = HEAP[loc];
     }
   }


### PR DESCRIPTION
Hi, cool project! While working on some larger program, I got a SEGFAULT:

```
==419558==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7dcd68fe4900 at pc 0x5585d30ef151 bp 0x7ffe63d09e10 sp 0x7ffe63d09e08
WRITE of size 8 at 0x7dcd68fe4900 thread T0
    #0 0x5585d30ef150 in count_uses /home/.../clang/./parse/count_uses.c:19:20
    #1 0x5585d30ec777 in parse_term_dup /home/.../clang/./parse/term/dup.c:201:16
    #2 0x5585d30ea052 in parse_term_atom /home/.../clang/./parse/term/_.c:7:12
    #3 0x5585d30e970a in parse_term /home/.../clang/./parse/term/_.c:40:25
...
```

Apparently you restricted the traversal stack in `count_uses` to 1024, which obviously fails on larger programs. I implemented a simple fix with an automatically growing cap, though let me know if this doesn't fit your style.

A minimal reproduction using a long string (1025 chars):

```
@main =
! x = 0;
"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
```